### PR TITLE
Set allow_pickle as `True`

### DIFF
--- a/mnist-cnn/training/mnist-cnn.py
+++ b/mnist-cnn/training/mnist-cnn.py
@@ -156,7 +156,7 @@ def run_test(weights_file, test_file):
     output_names = ['prob']
     output_names.extend(monitor_names)
 
-    param_dict = np.load(weights_file, encoding='latin1').item()
+    param_dict = np.load(weights_file, encoding='latin1', allow_pickle=True).item()
     predictor = OfflinePredictor(PredictConfig(
         model=Model(),
         session_init=DictRestore(param_dict),


### PR DESCRIPTION
According to change at https://github.com/numpy/numpy/pull/13359/commits/8cea82a54a36b2232b484c7a50a32cefcb85e6bf, the default value allow_pickle is changed as `False`. So, to overcome the problem for new versions of numpy, it is needed to set as `True` when calling the `load` function.